### PR TITLE
feat: add scaffold_plugin tool for generating Claude Code plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is Canto
 
-Canto is an MCP server that is also an MCP generator. A user tells the LLM what they need — a custom plugin, MCP server, skill, or any combination. The LLM queries Canto with those requirements in the format the server accepts. Canto scaffolds the files and premakes the structure so it works universally. The LLM then makes further queries to refine and tailor the output based on the user's specific request, and outputs the finished skill, MCP, or plugin to the desired location.
+Canto is an MCP server that is also an MCP generator. A user tells the LLM what they need — a custom plugin, MCP server, skill, or any combination. The LLM queries Canto with those requirements in the format the server accepts. Canto scaffolds the files and prepares the structure so it works universally. The LLM then makes further queries to refine and tailor the output based on the user's specific request, and outputs the finished skill, MCP, or plugin to the desired location.
 
 Generated MCPs will always need to be configured for the specific task, but the scaffolded structure is complete and functional.
 
@@ -63,7 +63,7 @@ src/
 
 ### Data flow
 
-Every read tool: **handler → `readInstalledPlugins()` → reader(s) → filter/format → JSON response**. No caching; filesystem read fresh each call.
+Every read tool: **handler → `readInstalledPlugins()` → reader(s) → filter/format → JSON response**. No caching; the filesystem is read fresh on each call.
 
 ### Key filesystem paths
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is Canto
+
+Canto is an MCP server that is also an MCP generator. A user tells the LLM what they need — a custom plugin, MCP server, skill, or any combination. The LLM queries Canto with those requirements in the format the server accepts. Canto scaffolds the files and premakes the structure so it works universally. The LLM then makes further queries to refine and tailor the output based on the user's specific request, and outputs the finished skill, MCP, or plugin to the desired location.
+
+Generated MCPs will always need to be configured for the specific task, but the scaffolded structure is complete and functional.
+
+The current codebase implements the **read/query side**: tools to inspect the user's installed plugin ecosystem so Canto understands existing conventions and structures. **The generation/scaffold tools are not yet implemented** — that is the core remaining work.
+
+## Build & Run
+
+```bash
+npm run build        # tsc → dist/
+npm run dev          # tsc --watch
+npm start            # node dist/index.js (stdio transport)
+```
+
+No test framework or linter is configured.
+
+## Architecture
+
+MCP server using `@modelcontextprotocol/sdk` over stdio transport. Entry point: `src/index.ts`.
+
+### Current tools (read/query)
+
+| Tool              | Purpose                                                  |
+| ----------------- | -------------------------------------------------------- |
+| `list_plugins`    | List installed plugins with metadata                     |
+| `list_mcps`       | List MCP servers from installed plugins                  |
+| `get_mcp_details` | Full config for a specific MCP server                    |
+| `list_skills`     | List skills from plugins and user-created                |
+| `get_skill_content` | Full content of a skill by name                        |
+| `search_skills`   | Keyword search across skill names, descriptions, content |
+
+### Needed tools (generate/scaffold)
+
+Tools that accept requirements and output working plugin/MCP/skill structures to the filesystem. MCPs will always need user configuration for their specific task but should be structurally complete.
+
+### Source layout
+
+```text
+src/
+├── index.ts              # Server setup, tool registration
+├── types.ts              # All interfaces + Zod input schemas
+├── readers/              # Filesystem data access
+│   ├── plugin-reader.ts  # Reads ~/.claude/plugins/installed_plugins.json + plugin.json
+│   ├── mcp-reader.ts     # Reads .mcp.json from plugin install paths
+│   └── skill-reader.ts   # Reads skills/*/SKILL.md from plugins and ~/.claude/skills/
+├── tools/                # Tool handlers (one per file)
+│   ├── list-plugins.ts
+│   ├── list-mcps.ts
+│   ├── get-mcp-details.ts
+│   ├── list-skills.ts
+│   ├── get-skill-content.ts
+│   └── search-skills.ts
+└── utils/
+    ├── paths.ts          # Canonical paths (~/.claude, ~/.claude/plugins, ~/.claude/skills)
+    └── frontmatter.ts    # YAML frontmatter parser for SKILL.md files
+```
+
+### Data flow
+
+Every read tool: **handler → `readInstalledPlugins()` → reader(s) → filter/format → JSON response**. No caching; filesystem read fresh each call.
+
+### Key filesystem paths
+
+- `~/.claude/plugins/installed_plugins.json` — plugin registry
+- `<plugin-install-path>/.claude-plugin/plugin.json` — plugin metadata
+- `<plugin-install-path>/.mcp.json` — plugin's MCP server configs
+- `<plugin-install-path>/skills/*/SKILL.md` — plugin skills
+- `~/.claude/skills/*/SKILL.md` — user-created skills
+
+## Conventions
+
+- ESM-only (`"type": "module"`). All local imports use `.js` extensions.
+- TypeScript strict mode, target ES2022, Node16 module resolution.
+- Tool handlers are pure async functions, one per file in `src/tools/`.
+- Zod schemas for tool inputs live in `src/types.ts`; `.shape` passed to `server.tool()`.
+- Raw interfaces for internal data structures; Zod only at the tool boundary.

--- a/docs/plans/2026-02-15-canto-generation-design.md
+++ b/docs/plans/2026-02-15-canto-generation-design.md
@@ -1,0 +1,205 @@
+# Canto: Missing Generation Functionality Design
+
+## Context
+
+Canto is an MCP server that generates other MCP servers, Claude Code plugins, and skills. The read/query tools exist (list_plugins, list_mcps, list_skills, etc.) but the core generation tools are missing. The user needs a single `scaffold_plugin` tool that accepts requirements and outputs a working, universal plugin structure — with any combination of components (MCP server, skills, commands, agents, hooks).
+
+## Design Decisions
+
+- **Output mode**: Configurable — write to filesystem OR return as JSON response
+- **Generator style**: Single all-in-one tool (not individual per-component tools)
+- **MCP stack**: TypeScript only (MCP SDK + stdio transport)
+- **Conflict resolution**: Fail with error on name collisions — never overwrite
+- **Pre-checks**: Always query the installed ecosystem before generating to detect conflicts
+
+---
+
+## Missing Functionality
+
+### 1. New Tool: `scaffold_plugin`
+
+Accept a structured description of what to generate and output a complete, working plugin.
+
+**Input schema**:
+
+```typescript
+ScaffoldPluginInput = z.object({
+  name: z.string().describe("Plugin name (kebab-case)"),
+  description: z.string().describe("What this plugin does"),
+  author: z.object({
+    name: z.string(),
+    email: z.string().optional(),
+  }).optional(),
+  outputPath: z.string().describe("Where to write the plugin (absolute path)"),
+  writeToDisk: z.boolean().default(true).describe("Write files to disk or return as JSON"),
+
+  components: z.object({
+    mcp: z.object({
+      serverName: z.string().describe("MCP server name"),
+      tools: z.array(z.object({
+        name: z.string(),
+        description: z.string(),
+        parameters: z.array(z.object({
+          name: z.string(),
+          type: z.enum(["string", "number", "boolean", "enum"]),
+          description: z.string(),
+          required: z.boolean().default(true),
+          enumValues: z.array(z.string()).optional(),
+          default: z.string().optional(),
+        })).optional(),
+      })).min(1),
+      transport: z.enum(["stdio", "http"]).default("stdio"),
+    }).optional().describe("Generate an MCP server"),
+
+    skills: z.array(z.object({
+      name: z.string(),
+      description: z.string(),
+      content: z.string().describe("Skill body content (markdown)"),
+    })).optional().describe("Generate skill files"),
+
+    commands: z.array(z.object({
+      name: z.string(),
+      description: z.string(),
+      argumentHint: z.string().optional(),
+      allowedTools: z.array(z.string()).optional(),
+      body: z.string().describe("Command instructions (markdown)"),
+    })).optional().describe("Generate slash commands"),
+
+    agents: z.array(z.object({
+      name: z.string(),
+      description: z.string(),
+      tools: z.array(z.string()).optional(),
+      color: z.string().optional(),
+      systemPrompt: z.string().describe("Agent system prompt (markdown)"),
+    })).optional().describe("Generate agent definitions"),
+
+    hooks: z.object({
+      sessionStart: z.array(z.object({
+        matcher: z.string(),
+        command: z.string(),
+        timeout: z.number().default(5),
+      })).optional(),
+      preToolUse: z.array(z.object({
+        matcher: z.string(),
+        command: z.string(),
+        timeout: z.number().default(5),
+      })).optional(),
+      postToolUse: z.array(z.object({
+        matcher: z.string(),
+        command: z.string(),
+        timeout: z.number().default(5),
+      })).optional(),
+    }).optional().describe("Generate lifecycle hooks"),
+  }),
+});
+```
+
+**Generated output structure**:
+
+```text
+<outputPath>/<name>/
+├── .claude-plugin/
+│   └── plugin.json
+├── .mcp.json                    (if components.mcp)
+├── package.json                 (if components.mcp)
+├── tsconfig.json                (if components.mcp)
+├── src/
+│   ├── index.ts                 (if components.mcp)
+│   ├── types.ts                 (if components.mcp)
+│   └── tools/
+│       └── <tool-name>.ts       (if components.mcp, one per tool)
+├── skills/
+│   └── <skill-name>/
+│       └── SKILL.md             (if components.skills)
+├── commands/
+│   └── <command-name>.md        (if components.commands)
+├── agents/
+│   └── <agent-name>.md          (if components.agents)
+└── hooks/
+    ├── hooks.json               (if components.hooks)
+    └── <hook-scripts>.sh        (if components.hooks)
+```
+
+### 2. New Source Layer: `src/generators/`
+
+Mirrors the `src/readers/` pattern. Each generator produces file content from structured input:
+
+- **`plugin-generator.ts`** — Generates `.claude-plugin/plugin.json` manifest
+- **`mcp-generator.ts`** — Generates full MCP server: `package.json`, `tsconfig.json`, `src/index.ts` (with McpServer setup + tool registrations), `src/types.ts` (Zod schemas from parameter defs), `src/tools/*.ts` (handler stubs), `.mcp.json`
+- **`skill-generator.ts`** — Generates `skills/<name>/SKILL.md` with frontmatter + content
+- **`command-generator.ts`** — Generates `commands/<name>.md` with YAML frontmatter + body
+- **`agent-generator.ts`** — Generates `agents/<name>.md` with YAML frontmatter + system prompt
+- **`hook-generator.ts`** — Generates `hooks/hooks.json` + shell script stubs
+
+### 3. New Utility: `src/utils/writer.ts`
+
+Handles the configurable output mode:
+
+- `writeToDisk: true` — creates directories, writes files
+- `writeToDisk: false` — returns `{ files: [{ path, content }] }` as JSON
+
+### 4. New Types in `src/types.ts`
+
+- `ScaffoldPluginInput` — Zod schema (above)
+- `GeneratedFile` — `{ relativePath: string; content: string }`
+- `ScaffoldResult` — `{ pluginPath: string; files: GeneratedFile[] }`
+- Per-generator input interfaces
+
+### 5. New Utility: `src/utils/conflict-checker.ts`
+
+Pre-generation conflict detection. Reuses the existing readers internally:
+
+- **Plugin name**: Calls `readInstalledPlugins()` — checks if any `ResolvedPlugin.name` matches
+- **MCP server name**: Calls `readMcpServers()` — checks if any `McpServerConfig.serverName` matches
+- **Skill name**: Calls `readAllSkills()` — checks if any `SkillInfo.name` matches
+- **Output path**: Checks if `<outputPath>/<name>/` already exists on disk
+
+Returns a list of conflicts. If any exist, the tool returns an error response describing each collision (what exists, where it lives) so the LLM can rename or ask the user.
+
+### 6. New Tool Handler: `src/tools/scaffold-plugin.ts`
+
+Orchestrates the generators:
+
+1. Parse input
+2. **Run conflict checks** — fail with descriptive error if any collisions found
+3. Always generate plugin.json manifest
+4. Conditionally call each generator based on which components are present
+5. Collect all `GeneratedFile[]`
+6. Either write to disk or return as JSON based on `writeToDisk`
+
+---
+
+## Files to Create
+
+| File                                 | Purpose                                                  |
+| ------------------------------------ | -------------------------------------------------------- |
+| `src/tools/scaffold-plugin.ts`       | Tool handler for scaffold_plugin                         |
+| `src/generators/plugin-generator.ts` | Generates plugin.json manifest                           |
+| `src/generators/mcp-generator.ts`    | Generates full MCP server scaffold                       |
+| `src/generators/skill-generator.ts`  | Generates SKILL.md files                                 |
+| `src/generators/command-generator.ts` | Generates command .md files                             |
+| `src/generators/agent-generator.ts`  | Generates agent .md files                                |
+| `src/generators/hook-generator.ts`   | Generates hooks.json + scripts                           |
+| `src/utils/writer.ts`               | Configurable file writer (disk or JSON)                  |
+| `src/utils/conflict-checker.ts`     | Pre-generation collision detection using existing readers |
+
+## Files to Modify
+
+| File            | Change                                                           |
+| --------------- | ---------------------------------------------------------------- |
+| `src/index.ts`  | Register `scaffold_plugin` tool                                  |
+| `src/types.ts`  | Add `ScaffoldPluginInput`, `GeneratedFile`, `ScaffoldResult` types |
+
+---
+
+## Verification
+
+1. `npm run build` — compiles without errors
+2. Start the server: `npm start`
+3. Test with a minimal plugin (just a skill):
+   ```json
+   { "name": "test-plugin", "description": "Test", "outputPath": "/tmp", "components": { "skills": [{ "name": "my-skill", "description": "A test skill", "content": "# Test\nDo the thing." }] } }
+   ```
+4. Verify generated files exist at `/tmp/test-plugin/` with correct structure
+5. Test with `writeToDisk: false` and verify JSON response contains all files
+6. Test full plugin with MCP server + skills + commands — verify generated MCP server compiles with `cd /tmp/test-plugin && npm install && npm run build`

--- a/src/generators/agent-generator.ts
+++ b/src/generators/agent-generator.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { AgentComponentSchema } from "../types.js";
+import type { GeneratedFile } from "../types.js";
+
+type AgentInput = z.infer<typeof AgentComponentSchema>;
+
+export function generateAgent(agent: AgentInput): GeneratedFile {
+  const frontmatterLines = [
+    "---",
+    `name: ${agent.name}`,
+    `description: ${agent.description}`,
+    `model: ${agent.model}`,
+    `color: ${agent.color}`,
+  ];
+
+  if (agent.tools && agent.tools.length > 0) {
+    frontmatterLines.push(`tools: [${agent.tools.map((t) => `"${t}"`).join(", ")}]`);
+  }
+
+  frontmatterLines.push("---");
+
+  const content = `${frontmatterLines.join("\n")}\n\n${agent.systemPrompt}\n`;
+
+  return {
+    relativePath: `agents/${agent.name}.md`,
+    content,
+  };
+}
+
+export function generateAgents(agents: AgentInput[]): GeneratedFile[] {
+  return agents.map(generateAgent);
+}

--- a/src/generators/agent-generator.ts
+++ b/src/generators/agent-generator.ts
@@ -1,20 +1,23 @@
 import { z } from "zod";
 import { AgentComponentSchema } from "../types.js";
 import type { GeneratedFile } from "../types.js";
+import { appendYamlField, escapeYamlString } from "../utils/yaml.js";
 
 type AgentInput = z.infer<typeof AgentComponentSchema>;
 
 export function generateAgent(agent: AgentInput): GeneratedFile {
-  const frontmatterLines = [
-    "---",
-    `name: ${agent.name}`,
-    `description: ${agent.description}`,
-    `model: ${agent.model}`,
-    `color: ${agent.color}`,
-  ];
+  const frontmatterLines: string[] = ["---"];
+
+  appendYamlField(frontmatterLines, "name", agent.name);
+  appendYamlField(frontmatterLines, "description", agent.description);
+  appendYamlField(frontmatterLines, "model", agent.model);
+  appendYamlField(frontmatterLines, "color", agent.color);
 
   if (agent.tools && agent.tools.length > 0) {
-    frontmatterLines.push(`tools: [${agent.tools.map((t) => `"${t}"`).join(", ")}]`);
+    const toolsList = agent.tools
+      .map((t) => `"${escapeYamlString(t)}"`)
+      .join(", ");
+    frontmatterLines.push(`tools: [${toolsList}]`);
   }
 
   frontmatterLines.push("---");

--- a/src/generators/command-generator.ts
+++ b/src/generators/command-generator.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { CommandComponentSchema } from "../types.js";
+import type { GeneratedFile } from "../types.js";
+
+type CommandInput = z.infer<typeof CommandComponentSchema>;
+
+export function generateCommand(command: CommandInput): GeneratedFile {
+  const frontmatterLines = [
+    "---",
+    `description: ${command.description}`,
+  ];
+
+  if (command.argumentHint) {
+    frontmatterLines.push(`argument-hint: ${command.argumentHint}`);
+  }
+
+  if (command.allowedTools && command.allowedTools.length > 0) {
+    frontmatterLines.push(`allowed-tools: [${command.allowedTools.join(", ")}]`);
+  }
+
+  if (command.model) {
+    frontmatterLines.push(`model: ${command.model}`);
+  }
+
+  if (command.disableModelInvocation) {
+    frontmatterLines.push(`disable-model-invocation: true`);
+  }
+
+  frontmatterLines.push("---");
+
+  const content = `${frontmatterLines.join("\n")}\n\n${command.body}\n`;
+
+  return {
+    relativePath: `commands/${command.name}.md`,
+    content,
+  };
+}
+
+export function generateCommands(commands: CommandInput[]): GeneratedFile[] {
+  return commands.map(generateCommand);
+}

--- a/src/generators/command-generator.ts
+++ b/src/generators/command-generator.ts
@@ -1,21 +1,24 @@
 import { z } from "zod";
 import { CommandComponentSchema } from "../types.js";
 import type { GeneratedFile } from "../types.js";
+import { appendYamlField, escapeYamlString } from "../utils/yaml.js";
 
 type CommandInput = z.infer<typeof CommandComponentSchema>;
 
 export function generateCommand(command: CommandInput): GeneratedFile {
-  const frontmatterLines = [
-    "---",
-    `description: ${command.description}`,
-  ];
+  const frontmatterLines: string[] = ["---"];
+
+  appendYamlField(frontmatterLines, "description", command.description);
 
   if (command.argumentHint) {
-    frontmatterLines.push(`argument-hint: ${command.argumentHint}`);
+    appendYamlField(frontmatterLines, "argument-hint", command.argumentHint);
   }
 
   if (command.allowedTools && command.allowedTools.length > 0) {
-    frontmatterLines.push(`allowed-tools: [${command.allowedTools.join(", ")}]`);
+    const quotedTools = command.allowedTools.map((tool) =>
+      `"${escapeYamlString(tool)}"`
+    );
+    frontmatterLines.push(`allowed-tools: [${quotedTools.join(", ")}]`);
   }
 
   if (command.model) {

--- a/src/generators/hook-generator.ts
+++ b/src/generators/hook-generator.ts
@@ -74,8 +74,8 @@ export function generateHooks(hooks: HooksInput): GeneratedFile[] {
 
     // Collect script names for command-type hooks
     for (const entry of entries) {
-      if (entry.type === "command" && entry.command) {
-        scriptNames.add(toScriptName(entry.command));
+      if (entry.type === "command") {
+        scriptNames.add(toScriptName(entry.command ?? "hook"));
       }
     }
   }

--- a/src/generators/hook-generator.ts
+++ b/src/generators/hook-generator.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+import { HooksComponentSchema, HookEntrySchema } from "../types.js";
+import type { GeneratedFile } from "../types.js";
+
+type HooksInput = z.infer<typeof HooksComponentSchema>;
+type HookEntry = z.infer<typeof HookEntrySchema>;
+
+interface HookJsonInnerEntry {
+  type: "command" | "prompt";
+  command?: string;
+  prompt?: string;
+  timeout: number;
+  async?: boolean;
+}
+
+interface HookJsonEntry {
+  matcher?: string;
+  hooks: HookJsonInnerEntry[];
+}
+
+// Map from camelCase schema keys to PascalCase Claude Code event names
+const EVENT_MAP: Record<string, string> = {
+  sessionStart: "SessionStart",
+  sessionEnd: "SessionEnd",
+  preToolUse: "PreToolUse",
+  postToolUse: "PostToolUse",
+  stop: "Stop",
+  subagentStop: "SubagentStop",
+  userPromptSubmit: "UserPromptSubmit",
+  preCompact: "PreCompact",
+  notification: "Notification",
+};
+
+function toScriptName(input: string): string {
+  if (input.endsWith(".sh") || input.endsWith(".py")) return input;
+  return input.replace(/[^a-zA-Z0-9-]/g, "-").replace(/-+/g, "-") + ".sh";
+}
+
+function buildHookEntry(entry: HookEntry): HookJsonEntry {
+  const inner: HookJsonInnerEntry = {
+    type: entry.type,
+    timeout: entry.timeout,
+  };
+
+  if (entry.type === "command") {
+    const scriptName = toScriptName(entry.command ?? "hook");
+    inner.command = `\${CLAUDE_PLUGIN_ROOT}/hooks/${scriptName}`;
+  } else {
+    inner.prompt = entry.prompt ?? "";
+  }
+
+  if (entry.async !== undefined) {
+    inner.async = entry.async;
+  }
+
+  const result: HookJsonEntry = { hooks: [inner] };
+  if (entry.matcher) {
+    result.matcher = entry.matcher;
+  }
+
+  return result;
+}
+
+export function generateHooks(hooks: HooksInput): GeneratedFile[] {
+  const files: GeneratedFile[] = [];
+  const hooksJson: Record<string, HookJsonEntry[]> = {};
+  const scriptNames = new Set<string>();
+
+  for (const [key, eventName] of Object.entries(EVENT_MAP)) {
+    const entries = hooks[key as keyof HooksInput];
+    if (!entries || entries.length === 0) continue;
+
+    hooksJson[eventName] = entries.map(buildHookEntry);
+
+    // Collect script names for command-type hooks
+    for (const entry of entries) {
+      if (entry.type === "command" && entry.command) {
+        scriptNames.add(toScriptName(entry.command));
+      }
+    }
+  }
+
+  files.push({
+    relativePath: "hooks/hooks.json",
+    content: JSON.stringify({ hooks: hooksJson }, null, 2) + "\n",
+  });
+
+  // Generate stub shell scripts for command hooks
+  for (const scriptName of scriptNames) {
+    files.push({
+      relativePath: `hooks/${scriptName}`,
+      content: [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "",
+        "# Hook receives JSON on stdin with session context",
+        "# Output JSON to stdout for hook response",
+        "# Exit 0 = success, Exit 2 = blocking error",
+        "",
+        "# TODO: Implement hook logic",
+        `echo '{"continue": true}'`,
+        "",
+      ].join("\n"),
+    });
+  }
+
+  return files;
+}

--- a/src/generators/mcp-generator.ts
+++ b/src/generators/mcp-generator.ts
@@ -1,0 +1,276 @@
+import { z } from "zod";
+import { McpComponentSchema, McpToolSchema, ToolParameterSchema } from "../types.js";
+import type { GeneratedFile } from "../types.js";
+
+type McpInput = z.infer<typeof McpComponentSchema>;
+type McpTool = z.infer<typeof McpToolSchema>;
+type ToolParam = z.infer<typeof ToolParameterSchema>;
+
+function toSnakeCase(name: string): string {
+  return name.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_|_$/g, "").toLowerCase();
+}
+
+function toPascalCase(name: string): string {
+  return name.split(/[-_]+/).map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join("");
+}
+
+function toCamelCase(name: string): string {
+  const pascal = toPascalCase(name);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}
+
+// ─── package.json ───
+
+function generatePackageJson(pluginName: string): GeneratedFile {
+  const pkg = {
+    name: pluginName,
+    version: "1.0.0",
+    description: `MCP server for ${pluginName}`,
+    type: "module",
+    main: "dist/index.js",
+    scripts: {
+      build: "tsc",
+      start: "node dist/index.js",
+      dev: "tsc --watch",
+    },
+    dependencies: {
+      "@modelcontextprotocol/sdk": "^1.12.1",
+      zod: "^3.24.0",
+    },
+    devDependencies: {
+      "@types/node": "^22.0.0",
+      typescript: "^5.7.0",
+    },
+  };
+
+  return {
+    relativePath: "package.json",
+    content: JSON.stringify(pkg, null, 2) + "\n",
+  };
+}
+
+// ─── tsconfig.json ───
+
+function generateTsconfig(): GeneratedFile {
+  const config = {
+    compilerOptions: {
+      target: "ES2022",
+      module: "Node16",
+      moduleResolution: "Node16",
+      outDir: "./dist",
+      rootDir: "./src",
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      forceConsistentCasingInFileNames: true,
+      resolveJsonModule: true,
+      declaration: true,
+      sourceMap: true,
+    },
+    include: ["src/**/*"],
+    exclude: ["node_modules", "dist"],
+  };
+
+  return {
+    relativePath: "tsconfig.json",
+    content: JSON.stringify(config, null, 2) + "\n",
+  };
+}
+
+// ─── .mcp.json ───
+
+function generateMcpJson(mcp: McpInput): GeneratedFile {
+  const config: Record<string, unknown> = {};
+
+  if (mcp.transport === "stdio") {
+    config[mcp.serverName] = {
+      command: "node",
+      args: ["${CLAUDE_PLUGIN_ROOT}/dist/index.js"],
+    };
+  } else {
+    config[mcp.serverName] = {
+      type: "http",
+      url: "https://localhost:3000/mcp",
+    };
+  }
+
+  return {
+    relativePath: ".mcp.json",
+    content: JSON.stringify({ mcpServers: config }, null, 2) + "\n",
+  };
+}
+
+// ─── Zod type mapping ───
+
+function zodType(param: ToolParam): string {
+  switch (param.type) {
+    case "string":
+      return "z.string()";
+    case "number":
+      return "z.number()";
+    case "boolean":
+      return "z.boolean()";
+    case "enum":
+      if (param.enumValues && param.enumValues.length > 0) {
+        const values = param.enumValues.map((v) => `"${v}"`).join(", ");
+        return `z.enum([${values}])`;
+      }
+      return "z.string()";
+    default:
+      return "z.string()";
+  }
+}
+
+function zodField(param: ToolParam): string {
+  let field = zodType(param);
+
+  if (!param.required) {
+    field += ".optional()";
+  }
+
+  if (param.defaultValue !== undefined) {
+    field += `.default(${JSON.stringify(param.defaultValue)})`;
+  }
+
+  field += `.describe(${JSON.stringify(param.description)})`;
+  return field;
+}
+
+// ─── src/types.ts ───
+
+function generateTypesFile(tools: McpTool[]): GeneratedFile {
+  const lines: string[] = ['import { z } from "zod";', ""];
+
+  for (const tool of tools) {
+    const schemaName = `${toPascalCase(tool.name)}Input`;
+    if (!tool.parameters || tool.parameters.length === 0) {
+      lines.push(`export const ${schemaName} = z.object({});`);
+    } else {
+      lines.push(`export const ${schemaName} = z.object({`);
+      for (const param of tool.parameters) {
+        lines.push(`  ${toCamelCase(param.name)}: ${zodField(param)},`);
+      }
+      lines.push("});");
+    }
+    lines.push("");
+  }
+
+  return {
+    relativePath: "src/types.ts",
+    content: lines.join("\n"),
+  };
+}
+
+// ─── src/tools/<tool-name>.ts ───
+
+function generateToolHandler(tool: McpTool): GeneratedFile {
+  const snakeName = toSnakeCase(tool.name);
+  const pascalName = toPascalCase(tool.name);
+  const schemaName = `${pascalName}Input`;
+  const handlerName = `handle${pascalName}`;
+  const hasParams = tool.parameters && tool.parameters.length > 0;
+
+  const lines: string[] = [];
+
+  if (hasParams) {
+    lines.push(`import { z } from "zod";`);
+    lines.push(`import { ${schemaName} } from "../types.js";`);
+    lines.push("");
+    lines.push(`type ${pascalName}Params = z.infer<typeof ${schemaName}>;`);
+    lines.push("");
+    lines.push(`export async function ${handlerName}(params: ${pascalName}Params) {`);
+  } else {
+    lines.push(`export async function ${handlerName}() {`);
+  }
+
+  lines.push("  // TODO: Implement tool logic");
+  lines.push(`  const result = { status: "ok", tool: "${snakeName}" };`);
+  lines.push("");
+  lines.push("  return {");
+  lines.push('    content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],');
+  lines.push("  };");
+  lines.push("}");
+  lines.push("");
+
+  return {
+    relativePath: `src/tools/${snakeName}.ts`,
+    content: lines.join("\n"),
+  };
+}
+
+// ─── src/index.ts ───
+
+function generateIndexFile(mcp: McpInput): GeneratedFile {
+  const lines: string[] = [
+    'import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";',
+    'import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";',
+  ];
+
+  // Import schemas and handlers
+  for (const tool of mcp.tools) {
+    const pascalName = toPascalCase(tool.name);
+    const snakeName = toSnakeCase(tool.name);
+    const hasParams = tool.parameters && tool.parameters.length > 0;
+
+    if (hasParams) {
+      lines.push(`import { ${pascalName}Input } from "./types.js";`);
+    }
+    lines.push(`import { handle${pascalName} } from "./tools/${snakeName}.js";`);
+  }
+
+  lines.push("");
+  lines.push("const server = new McpServer({");
+  lines.push(`  name: ${JSON.stringify(mcp.serverName)},`);
+  lines.push('  version: "1.0.0",');
+  lines.push("});");
+  lines.push("");
+
+  // Register tools
+  for (const tool of mcp.tools) {
+    const snakeName = toSnakeCase(tool.name);
+    const pascalName = toPascalCase(tool.name);
+    const hasParams = tool.parameters && tool.parameters.length > 0;
+
+    lines.push("server.tool(");
+    lines.push(`  ${JSON.stringify(snakeName)},`);
+    lines.push(`  ${JSON.stringify(tool.description)},`);
+
+    if (hasParams) {
+      lines.push(`  ${pascalName}Input.shape,`);
+      lines.push(`  async (params) => handle${pascalName}(params),`);
+    } else {
+      lines.push("  {},");
+      lines.push(`  async () => handle${pascalName}(),`);
+    }
+
+    lines.push(");");
+    lines.push("");
+  }
+
+  lines.push("const transport = new StdioServerTransport();");
+  lines.push("await server.connect(transport);");
+  lines.push("");
+
+  return {
+    relativePath: "src/index.ts",
+    content: lines.join("\n"),
+  };
+}
+
+// ─── Public API ───
+
+export function generateMcpServer(pluginName: string, mcp: McpInput): GeneratedFile[] {
+  const files: GeneratedFile[] = [];
+
+  files.push(generatePackageJson(pluginName));
+  files.push(generateTsconfig());
+  files.push(generateMcpJson(mcp));
+  files.push(generateTypesFile(mcp.tools));
+  files.push(generateIndexFile(mcp));
+
+  for (const tool of mcp.tools) {
+    files.push(generateToolHandler(tool));
+  }
+
+  return files;
+}

--- a/src/generators/mcp-generator.ts
+++ b/src/generators/mcp-generator.ts
@@ -129,7 +129,16 @@ function zodField(param: ToolParam): string {
   }
 
   if (param.defaultValue !== undefined) {
-    field += `.default(${JSON.stringify(param.defaultValue)})`;
+    let coerced: unknown = param.defaultValue;
+    switch (param.type) {
+      case "number":
+        coerced = Number(param.defaultValue);
+        break;
+      case "boolean":
+        coerced = param.defaultValue === "true" || param.defaultValue === "1";
+        break;
+    }
+    field += `.default(${JSON.stringify(coerced)})`;
   }
 
   field += `.describe(${JSON.stringify(param.description)})`;

--- a/src/generators/mcp-generator.ts
+++ b/src/generators/mcp-generator.ts
@@ -11,7 +11,7 @@ function toSnakeCase(name: string): string {
 }
 
 function toPascalCase(name: string): string {
-  return name.split(/[-_]+/).map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join("");
+  return name.replace(/[^a-zA-Z0-9]+/g, " ").trim().split(/\s+/).map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join("");
 }
 
 function toCamelCase(name: string): string {
@@ -129,16 +129,7 @@ function zodField(param: ToolParam): string {
   }
 
   if (param.defaultValue !== undefined) {
-    let coerced: unknown = param.defaultValue;
-    switch (param.type) {
-      case "number":
-        coerced = Number(param.defaultValue);
-        break;
-      case "boolean":
-        coerced = param.defaultValue === "true" || param.defaultValue === "1";
-        break;
-    }
-    field += `.default(${JSON.stringify(coerced)})`;
+    field += `.default(${JSON.stringify(param.defaultValue)})`;
   }
 
   field += `.describe(${JSON.stringify(param.description)})`;

--- a/src/generators/plugin-generator.ts
+++ b/src/generators/plugin-generator.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { ScaffoldPluginInput } from "../types.js";
+import type { GeneratedFile } from "../types.js";
+
+type ScaffoldParams = z.infer<typeof ScaffoldPluginInput>;
+
+export function generatePluginManifest(params: ScaffoldParams): GeneratedFile {
+  const manifest: Record<string, unknown> = {
+    name: params.name,
+    description: params.description,
+    version: "1.0.0",
+  };
+
+  if (params.author) {
+    manifest.author = params.author;
+  }
+
+  if (params.components.skills) {
+    manifest.skills = "./skills/";
+  }
+
+  if (params.components.commands) {
+    manifest.commands = "./commands/";
+  }
+
+  if (params.components.hooks) {
+    manifest.hooks = "./hooks/hooks.json";
+  }
+
+  if (params.components.mcp) {
+    manifest.mcpServers = "./.mcp.json";
+  }
+
+  return {
+    relativePath: ".claude-plugin/plugin.json",
+    content: JSON.stringify(manifest, null, 2) + "\n",
+  };
+}

--- a/src/generators/skill-generator.ts
+++ b/src/generators/skill-generator.ts
@@ -1,19 +1,20 @@
 import { z } from "zod";
 import { SkillComponentSchema } from "../types.js";
 import type { GeneratedFile } from "../types.js";
+import { appendYamlField } from "../utils/yaml.js";
 
 type SkillInput = z.infer<typeof SkillComponentSchema>;
 
 export function generateSkill(skill: SkillInput): GeneratedFile {
-  const frontmatter = [
-    "---",
-    `name: ${skill.name}`,
-    `description: ${skill.description}`,
-    `version: ${skill.version}`,
-    "---",
-  ].join("\n");
+  const frontmatterLines: string[] = ["---"];
 
-  const content = `${frontmatter}\n\n${skill.content}\n`;
+  appendYamlField(frontmatterLines, "name", skill.name);
+  appendYamlField(frontmatterLines, "description", skill.description);
+  appendYamlField(frontmatterLines, "version", skill.version);
+
+  frontmatterLines.push("---");
+
+  const content = `${frontmatterLines.join("\n")}\n\n${skill.content}\n`;
 
   return {
     relativePath: `skills/${skill.name}/SKILL.md`,

--- a/src/generators/skill-generator.ts
+++ b/src/generators/skill-generator.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { SkillComponentSchema } from "../types.js";
+import type { GeneratedFile } from "../types.js";
+
+type SkillInput = z.infer<typeof SkillComponentSchema>;
+
+export function generateSkill(skill: SkillInput): GeneratedFile {
+  const frontmatter = [
+    "---",
+    `name: ${skill.name}`,
+    `description: ${skill.description}`,
+    `version: ${skill.version}`,
+    "---",
+  ].join("\n");
+
+  const content = `${frontmatter}\n\n${skill.content}\n`;
+
+  return {
+    relativePath: `skills/${skill.name}/SKILL.md`,
+    content,
+  };
+}
+
+export function generateSkills(skills: SkillInput[]): GeneratedFile[] {
+  return skills.map(generateSkill);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,16 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { GetMcpDetailsInput, ListSkillsInput, GetSkillContentInput, SearchSkillsInput } from "./types.js";
+import { GetMcpDetailsInput, ListSkillsInput, GetSkillContentInput, SearchSkillsInput, ScaffoldPluginInput } from "./types.js";
 import { handleListPlugins } from "./tools/list-plugins.js";
 import { handleListMcps } from "./tools/list-mcps.js";
 import { handleGetMcpDetails } from "./tools/get-mcp-details.js";
 import { handleListSkills } from "./tools/list-skills.js";
 import { handleGetSkillContent } from "./tools/get-skill-content.js";
 import { handleSearchSkills } from "./tools/search-skills.js";
+import { handleScaffoldPlugin } from "./tools/scaffold-plugin.js";
 
 const server = new McpServer({
-  name: "mcp-skills",
+  name: "canto",
   version: "1.0.0",
 });
 
@@ -53,6 +54,13 @@ server.tool(
   "Search skills by keyword across name, description, and content",
   SearchSkillsInput.shape,
   async (params) => handleSearchSkills(params),
+);
+
+server.tool(
+  "scaffold_plugin",
+  "Generate a complete Claude Code plugin with any combination of components (MCP server, skills, commands, agents, hooks). Outputs working, scaffolded structures ready for use. Checks for naming conflicts before generating.",
+  ScaffoldPluginInput.shape,
+  async (params) => handleScaffoldPlugin(params),
 );
 
 const transport = new StdioServerTransport();

--- a/src/tools/scaffold-plugin.ts
+++ b/src/tools/scaffold-plugin.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import { join } from "path";
+import { ScaffoldPluginInput } from "../types.js";
+import type { GeneratedFile } from "../types.js";
+import { checkConflicts } from "../utils/conflict-checker.js";
+import { writeFilesToDisk } from "../utils/writer.js";
+import { generatePluginManifest } from "../generators/plugin-generator.js";
+import { generateMcpServer } from "../generators/mcp-generator.js";
+import { generateSkills } from "../generators/skill-generator.js";
+import { generateCommands } from "../generators/command-generator.js";
+import { generateAgents } from "../generators/agent-generator.js";
+import { generateHooks } from "../generators/hook-generator.js";
+
+type ScaffoldParams = z.infer<typeof ScaffoldPluginInput>;
+
+export async function handleScaffoldPlugin(params: ScaffoldParams) {
+  // 1. Run conflict checks
+  const conflicts = await checkConflicts(params);
+  if (conflicts.length > 0) {
+    const details = conflicts.map((c) => `- [${c.type}] ${c.detail}`).join("\n");
+    return {
+      content: [{
+        type: "text" as const,
+        text: `Cannot scaffold plugin "${params.name}" due to conflicts:\n${details}\n\nRename the conflicting components or remove existing ones first.`,
+      }],
+      isError: true,
+    };
+  }
+
+  // 2. Collect all generated files
+  const files: GeneratedFile[] = [];
+
+  // Always generate plugin manifest
+  files.push(generatePluginManifest(params));
+
+  // Conditionally generate components
+  if (params.components.mcp) {
+    files.push(...generateMcpServer(params.name, params.components.mcp));
+  }
+
+  if (params.components.skills && params.components.skills.length > 0) {
+    files.push(...generateSkills(params.components.skills));
+  }
+
+  if (params.components.commands && params.components.commands.length > 0) {
+    files.push(...generateCommands(params.components.commands));
+  }
+
+  if (params.components.agents && params.components.agents.length > 0) {
+    files.push(...generateAgents(params.components.agents));
+  }
+
+  if (params.components.hooks) {
+    files.push(...generateHooks(params.components.hooks));
+  }
+
+  // 3. Write or return
+  const pluginPath = join(params.outputPath, params.name);
+
+  if (params.writeToDisk) {
+    await writeFilesToDisk(pluginPath, files);
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify({
+          status: "created",
+          pluginPath,
+          fileCount: files.length,
+          files: files.map((f) => f.relativePath),
+          components: {
+            manifest: true,
+            mcp: !!params.components.mcp,
+            skills: params.components.skills?.length ?? 0,
+            commands: params.components.commands?.length ?? 0,
+            agents: params.components.agents?.length ?? 0,
+            hooks: !!params.components.hooks,
+          },
+          nextSteps: params.components.mcp
+            ? [`cd ${pluginPath}`, "npm install", "npm run build"]
+            : [],
+        }, null, 2),
+      }],
+    };
+  }
+
+  // Return as JSON without writing
+  return {
+    content: [{
+      type: "text" as const,
+      text: JSON.stringify({
+        status: "generated",
+        pluginPath,
+        files: files.map((f) => ({
+          relativePath: f.relativePath,
+          content: f.content,
+        })),
+      }, null, 2),
+    }],
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,14 +118,39 @@ export interface ConflictEntry {
 }
 
 // ─── Scaffold Plugin Input ───
-const ToolParameterSchema = z.object({
+const BaseToolParameterSchema = z.object({
   name: z.string().describe("Parameter name"),
-  type: z.enum(["string", "number", "boolean", "enum"]).describe("Parameter type"),
   description: z.string().describe("What this parameter does"),
   required: z.boolean().default(true).describe("Whether this parameter is required"),
-  enumValues: z.array(z.string()).optional().describe("Allowed values if type is enum"),
+});
+
+const StringToolParameterSchema = BaseToolParameterSchema.extend({
+  type: z.literal("string").describe("Parameter type"),
   defaultValue: z.string().optional().describe("Default value"),
 });
+
+const NumberToolParameterSchema = BaseToolParameterSchema.extend({
+  type: z.literal("number").describe("Parameter type"),
+  defaultValue: z.number().optional().describe("Default value"),
+});
+
+const BooleanToolParameterSchema = BaseToolParameterSchema.extend({
+  type: z.literal("boolean").describe("Parameter type"),
+  defaultValue: z.boolean().optional().describe("Default value"),
+});
+
+const EnumToolParameterSchema = BaseToolParameterSchema.extend({
+  type: z.literal("enum").describe("Parameter type"),
+  enumValues: z.array(z.string()).describe("Allowed values if type is enum"),
+  defaultValue: z.string().optional().describe("Default value (must be one of enumValues)"),
+});
+
+const ToolParameterSchema = z.discriminatedUnion("type", [
+  StringToolParameterSchema,
+  NumberToolParameterSchema,
+  BooleanToolParameterSchema,
+  EnumToolParameterSchema,
+]);
 
 const McpToolSchema = z.object({
   name: z.string().describe("Tool name (snake_case)"),
@@ -170,7 +195,7 @@ const HookEntrySchema = z.object({
   type: z.enum(["command", "prompt"]).default("command").describe("Hook type: command (shell script) or prompt (LLM evaluation)"),
   command: z.string().optional().describe("Shell command to run (for type: command)"),
   prompt: z.string().optional().describe("LLM evaluation prompt (for type: prompt)"),
-  timeout: z.number().default(60).describe("Timeout in seconds (default 60 for command, 30 for prompt)"),
+  timeout: z.number().default(60).describe("Timeout in seconds"),
   async: z.boolean().optional().describe("Run hook asynchronously"),
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface InstalledPluginsRegistry {
 export interface PluginAuthor {
   name: string;
   email?: string;
+  url?: string;
 }
 
 export interface PluginMetadata {
@@ -97,3 +98,124 @@ export const SearchSkillsInput = z.object({
   source: z.enum(["all", "plugin", "user"]).optional().default("all")
     .describe("Filter search to a specific source"),
 });
+
+// ─── Generated File ───
+export interface GeneratedFile {
+  relativePath: string;
+  content: string;
+}
+
+export interface ScaffoldResult {
+  pluginPath: string;
+  files: GeneratedFile[];
+}
+
+// ─── Conflict ───
+export interface ConflictEntry {
+  type: "plugin" | "mcp-server" | "skill" | "output-path";
+  name: string;
+  detail: string;
+}
+
+// ─── Scaffold Plugin Input ───
+const ToolParameterSchema = z.object({
+  name: z.string().describe("Parameter name"),
+  type: z.enum(["string", "number", "boolean", "enum"]).describe("Parameter type"),
+  description: z.string().describe("What this parameter does"),
+  required: z.boolean().default(true).describe("Whether this parameter is required"),
+  enumValues: z.array(z.string()).optional().describe("Allowed values if type is enum"),
+  defaultValue: z.string().optional().describe("Default value"),
+});
+
+const McpToolSchema = z.object({
+  name: z.string().describe("Tool name (snake_case)"),
+  description: z.string().describe("What the tool does"),
+  parameters: z.array(ToolParameterSchema).optional().describe("Tool input parameters"),
+});
+
+const McpComponentSchema = z.object({
+  serverName: z.string().describe("MCP server name"),
+  tools: z.array(McpToolSchema).min(1).describe("Tools the MCP server exposes"),
+  transport: z.enum(["stdio", "http"]).default("stdio").describe("Transport type"),
+});
+
+const SkillComponentSchema = z.object({
+  name: z.string().describe("Skill name (kebab-case)"),
+  description: z.string().describe("When/why to use this skill — should start with 'This skill should be used when...'"),
+  version: z.string().default("0.1.0").describe("Semantic version (MAJOR.MINOR.PATCH)"),
+  content: z.string().describe("Skill body content (markdown)"),
+});
+
+const CommandComponentSchema = z.object({
+  name: z.string().describe("Command name (kebab-case)"),
+  description: z.string().describe("What the command does — shown in /help"),
+  argumentHint: z.string().optional().describe("Expected arguments hint e.g. '<pr-number>'"),
+  allowedTools: z.array(z.string()).optional().describe("Tools the command can use e.g. ['Read', 'Grep', 'Bash']"),
+  model: z.enum(["sonnet", "opus", "haiku"]).optional().describe("Model override"),
+  disableModelInvocation: z.boolean().optional().describe("If true, command is template only — no LLM invocation"),
+  body: z.string().describe("Command instructions FOR Claude (markdown) — not messages to user"),
+});
+
+const AgentComponentSchema = z.object({
+  name: z.string().describe("Agent name (kebab-case, 3-50 chars, alphanumeric start/end)"),
+  description: z.string().describe("When to invoke — must include 'Use this agent when...' and <example> blocks"),
+  model: z.enum(["inherit", "sonnet", "opus", "haiku"]).default("inherit").describe("Model to use"),
+  color: z.enum(["blue", "cyan", "green", "yellow", "magenta", "red"]).default("blue").describe("UI color"),
+  tools: z.array(z.string()).optional().describe("Available tools — omit for full access"),
+  systemPrompt: z.string().describe("Agent system prompt (markdown) — write in second person: 'You are...'"),
+});
+
+const HookEntrySchema = z.object({
+  matcher: z.string().optional().describe("Regex or pipe-separated tool names — omit to match all"),
+  type: z.enum(["command", "prompt"]).default("command").describe("Hook type: command (shell script) or prompt (LLM evaluation)"),
+  command: z.string().optional().describe("Shell command to run (for type: command)"),
+  prompt: z.string().optional().describe("LLM evaluation prompt (for type: prompt)"),
+  timeout: z.number().default(60).describe("Timeout in seconds (default 60 for command, 30 for prompt)"),
+  async: z.boolean().optional().describe("Run hook asynchronously"),
+});
+
+const HooksComponentSchema = z.object({
+  sessionStart: z.array(HookEntrySchema).optional(),
+  sessionEnd: z.array(HookEntrySchema).optional(),
+  preToolUse: z.array(HookEntrySchema).optional(),
+  postToolUse: z.array(HookEntrySchema).optional(),
+  stop: z.array(HookEntrySchema).optional(),
+  subagentStop: z.array(HookEntrySchema).optional(),
+  userPromptSubmit: z.array(HookEntrySchema).optional(),
+  preCompact: z.array(HookEntrySchema).optional(),
+  notification: z.array(HookEntrySchema).optional(),
+});
+
+const ComponentsSchema = z.object({
+  mcp: McpComponentSchema.optional().describe("Generate an MCP server"),
+  skills: z.array(SkillComponentSchema).optional().describe("Generate skill files"),
+  commands: z.array(CommandComponentSchema).optional().describe("Generate slash commands"),
+  agents: z.array(AgentComponentSchema).optional().describe("Generate agent definitions"),
+  hooks: HooksComponentSchema.optional().describe("Generate lifecycle hooks"),
+});
+
+export const ScaffoldPluginInput = z.object({
+  name: z.string().describe("Plugin name (kebab-case)"),
+  description: z.string().describe("What this plugin does"),
+  author: z.object({
+    name: z.string(),
+    email: z.string().optional(),
+    url: z.string().optional(),
+  }).optional().describe("Plugin author"),
+  outputPath: z.string().describe("Where to write the plugin (absolute path)"),
+  writeToDisk: z.boolean().default(true).describe("Write files to disk (true) or return as JSON (false)"),
+  components: ComponentsSchema,
+});
+
+// Re-export sub-schemas for generators
+export {
+  McpComponentSchema,
+  McpToolSchema,
+  ToolParameterSchema,
+  SkillComponentSchema,
+  CommandComponentSchema,
+  AgentComponentSchema,
+  HooksComponentSchema,
+  HookEntrySchema,
+  ComponentsSchema,
+};

--- a/src/utils/conflict-checker.ts
+++ b/src/utils/conflict-checker.ts
@@ -1,0 +1,68 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { readInstalledPlugins } from "../readers/plugin-reader.js";
+import { readMcpServers } from "../readers/mcp-reader.js";
+import { readAllSkills } from "../readers/skill-reader.js";
+import type { ConflictEntry } from "../types.js";
+import { z } from "zod";
+import { ScaffoldPluginInput } from "../types.js";
+
+type ScaffoldParams = z.infer<typeof ScaffoldPluginInput>;
+
+export async function checkConflicts(params: ScaffoldParams): Promise<ConflictEntry[]> {
+  const conflicts: ConflictEntry[] = [];
+  const plugins = await readInstalledPlugins();
+
+  // Check plugin name
+  const existingPlugin = plugins.find((p) => p.name === params.name);
+  if (existingPlugin) {
+    conflicts.push({
+      type: "plugin",
+      name: params.name,
+      detail: `Plugin "${params.name}" already installed at ${existingPlugin.installPath}`,
+    });
+  }
+
+  // Check MCP server name
+  if (params.components.mcp) {
+    const servers = await readMcpServers(plugins);
+    const existingServer = servers.find((s) => s.serverName === params.components.mcp!.serverName);
+    if (existingServer) {
+      conflicts.push({
+        type: "mcp-server",
+        name: params.components.mcp.serverName,
+        detail: `MCP server "${params.components.mcp.serverName}" already exists in plugin "${existingServer.sourcePluginName}"`,
+      });
+    }
+  }
+
+  // Check skill names
+  if (params.components.skills && params.components.skills.length > 0) {
+    const allSkills = await readAllSkills(plugins);
+    for (const skill of params.components.skills) {
+      const existingSkill = allSkills.find((s) => s.name === skill.name);
+      if (existingSkill) {
+        const source = existingSkill.source === "plugin"
+          ? `plugin "${existingSkill.sourcePluginName}"`
+          : "user skills";
+        conflicts.push({
+          type: "skill",
+          name: skill.name,
+          detail: `Skill "${skill.name}" already exists in ${source} at ${existingSkill.filePath}`,
+        });
+      }
+    }
+  }
+
+  // Check output path
+  const outputDir = join(params.outputPath, params.name);
+  if (existsSync(outputDir)) {
+    conflicts.push({
+      type: "output-path",
+      name: outputDir,
+      detail: `Output directory "${outputDir}" already exists`,
+    });
+  }
+
+  return conflicts;
+}

--- a/src/utils/writer.ts
+++ b/src/utils/writer.ts
@@ -1,0 +1,11 @@
+import { mkdir, writeFile } from "fs/promises";
+import { join, dirname } from "path";
+import type { GeneratedFile } from "../types.js";
+
+export async function writeFilesToDisk(basePath: string, files: GeneratedFile[]): Promise<void> {
+  for (const file of files) {
+    const fullPath = join(basePath, file.relativePath);
+    await mkdir(dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, file.content, "utf-8");
+  }
+}

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,0 +1,46 @@
+/**
+ * Safe YAML frontmatter serialization helpers.
+ *
+ * These produce double-quoted scalars for values that contain YAML-significant
+ * characters, and block scalars for multi-line values.
+ */
+
+const NEEDS_QUOTING = /[:{}\[\],&*?|>!%#@`"'\n\r]/;
+
+export function escapeYamlString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Format a scalar value for use in YAML frontmatter.
+ * - Multi-line strings use block scalar (`|-`)
+ * - Strings containing YAML-significant chars are double-quoted
+ * - Simple strings are emitted bare
+ */
+export function formatYamlValue(value: string): string {
+  if (value.includes("\n")) {
+    const indented = value
+      .split("\n")
+      .map((line) => `  ${line}`)
+      .join("\n");
+    return `|-\n${indented}`;
+  }
+
+  if (NEEDS_QUOTING.test(value)) {
+    return `"${escapeYamlString(value)}"`;
+  }
+
+  return value;
+}
+
+/**
+ * Append a `key: value` line to a frontmatter line array, with safe escaping.
+ */
+export function appendYamlField(
+  lines: string[],
+  key: string,
+  value: string | undefined | null,
+): void {
+  if (value == null) return;
+  lines.push(`${key}: ${formatYamlValue(value)}`);
+}


### PR DESCRIPTION
## Summary

- Adds `scaffold_plugin` MCP tool that accepts structured requirements and generates complete Claude Code plugin structures
- Generates any combination of: MCP servers, skills, commands, agents, hooks
- All output follows Anthropic's plugin-dev specifications (verified against installed plugin-dev skills)
- Pre-generation conflict detection prevents name collisions with existing plugins/MCPs/skills
- Configurable: write to filesystem or return as JSON
- Generated MCP servers compile out of the box (TypeScript + @modelcontextprotocol/sdk + stdio)

## Test plan

- [ ] `npm run build` compiles without errors
- [ ] Scaffold a minimal skill-only plugin and verify file structure
- [ ] Scaffold a full plugin (MCP + skill + command + agent + hooks) and verify all 13 files
- [ ] Generated MCP server passes `npm install && npm run build`
- [ ] Conflict detection blocks duplicate output paths
- [ ] `writeToDisk: false` returns JSON without writing files

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add a new scaffold_plugin MCP tool that generates complete Claude Code plugins from structured input, including optional MCP servers, skills, commands, agents, and hooks, with conflict detection and configurable output.

New Features:
- Introduce a ScaffoldPluginInput schema and related component schemas for describing plugin scaffolding requirements.
- Add the scaffold_plugin MCP tool entrypoint to the server to orchestrate plugin generation and conflict checking.
- Implement generators for MCP servers, plugin manifests, skills, commands, agents, and hooks, producing ready-to-use file structures.
- Add a configurable writer utility to either write generated files to disk or return them as JSON.
- Provide conflict detection utility to prevent name and path collisions when scaffolding plugins.
- Document Canto’s generation architecture and goals in a new CLAUDE.md and a design plan document for missing generation functionality.

Enhancements:
- Rename the MCP server from mcp-skills to canto and extend plugin author metadata with an optional URL field.

Documentation:
- Add CLAUDE.md to guide Claude Code when working in this repository and describe Canto’s purpose and architecture.
- Add a detailed design document outlining the planned generation functionality for Canto, including the scaffold_plugin tool.